### PR TITLE
Accept both ident and string as `io_name`

### DIFF
--- a/src/slang/macros.cr
+++ b/src/slang/macros.cr
@@ -1,7 +1,7 @@
 module Slang
 
   macro embed(filename, io_name)
-    \{{ run("slang/slang/process", {{filename}}, {{io_name}}) }}
+    \{{ run("slang/slang/process", {{filename}}, {{io_name.id.stringify}}) }}
   end
 
   # Use in a class


### PR DESCRIPTION
[`ECR.embed`](https://github.com/manastech/crystal/blob/583be7199364c0a4656ab59bcb443882961619ed/src/ecr/macros.cr#L82) accept both ident and string as `io_name`:

```crystal
require "ecr/macros"
name = "World"

io = MemoryIO.new
ECR.embed "greeting.ecr", io
io.to_s # => "Hello World!"

io = MemoryIO.new
ECR.embed "greeting.ecr", "io"
io.to_s # => "Hello World!"
```

I think it is better.