### PR TITLE
escaping attributes

### DIFF
--- a/spec/fixtures/interpolation-attr.slim
+++ b/spec/fixtures/interpolation-attr.slim
@@ -1,1 +1,1 @@
-input name="#{person["name"]}"
+input name="#{person["name"]}" value="hello"

--- a/spec/fixtures/interpolation-attr.slim
+++ b/spec/fixtures/interpolation-attr.slim
@@ -1,0 +1,1 @@
+input name="#{person["name"]}"

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -66,7 +66,7 @@ describe Slang do
     it "escapes output with single = " do
       val = %{"Hello" & world}
       render("span attr=val").should eq <<-HTML
-      <span attr="&quot;Hello&quot; &amp; world"></span>
+      <span attr="&quot;Hello&quot; & world"></span>
       HTML
     end
 

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -78,6 +78,12 @@ describe Slang do
       HTML
     end
 
+    it "should allow = at the end of attribute values" do
+      render(%{h1 id="asdf=" Hello}).should eq <<-HTML
+      <h1 id="asdf=">Hello</h1>
+      HTML
+    end
+
     # TODO: Implement?
     # it "does not escapes html with ==" do
     #   val = %{Hello & world}

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -70,6 +70,14 @@ describe Slang do
       HTML
     end
 
+    it "should allow quotes inside interpolated blocks " do
+      person = {"name" => "cris"}
+      res = render_file("spec/fixtures/interpolation-attr.slim")
+      res.should eq <<-HTML
+      <input name="cris">
+      HTML
+    end
+
     # TODO: Implement?
     # it "does not escapes html with ==" do
     #   val = %{Hello & world}

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -74,7 +74,7 @@ describe Slang do
       person = {"name" => "cris"}
       res = render_file("spec/fixtures/interpolation-attr.slim")
       res.should eq <<-HTML
-      <input name="cris">
+      <input name="cris" value="hello">
       HTML
     end
 

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -56,7 +56,6 @@ describe Slang do
       <span attr="hello world"></span>
       HTML
     end
-    
     it "allows dynamic classname" do
       klass = "my-class"
       render("span class=klass Foo").should eq <<-HTML
@@ -64,6 +63,20 @@ describe Slang do
       HTML
     end
 
+    it "escapes output with single = " do
+      val = %{"Hello" & world}
+      render("span attr=val").should eq <<-HTML
+      <span attr="&quot;Hello&quot; &amp; world"></span>
+      HTML
+    end
+
+    # TODO: Implement?
+    # it "does not escapes html with ==" do
+    #   val = %{Hello & world}
+    #   render("span attr==val").should eq <<-HTML
+    #   <span attr="Hello & world"></span>
+    #   HTML
+    # end
   end
 
   describe "output" do
@@ -189,5 +202,4 @@ describe Slang do
       HTML
     end
   end
-
 end

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -347,7 +347,7 @@ module Slang
           when '='
             str << current_char if is_str
             next_char
-            if current_char == '"'
+            if current_char == '"' && !is_str
               is_str = true
               str << current_char
               next_char

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -204,7 +204,6 @@ module Slang
       @token.value = "\"#{consume_text_line.strip}#{append_whitespace ? " " : ""}\""
     end
 
-
     private def consume_text_line
       consume_string escape_double_quotes: true
     end
@@ -342,6 +341,7 @@ module Slang
       String.build do |str|
         is_str = false
         is_in_parenthesis = false
+        is_in_interpolation = false
         loop do
           case current_char
           when '='
@@ -356,10 +356,23 @@ module Slang
               str << current_char
               next_char
             end
+          when '#'
+            str << current_char if is_str
+            next_char
+            if current_char == '{'
+              is_in_interpolation = true
+              str << current_char
+              next_char
+            end
           when '"'
             str << current_char
             next_char
-            break
+            break if is_in_interpolation == false
+          when "}"
+            str << current_char if is_str
+            if is_in_interpolation
+              is_in_interpolation = false
+            end
           when ')'
             str << current_char
             next_char

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -368,8 +368,9 @@ module Slang
             str << current_char
             next_char
             break if is_in_interpolation == false
-          when "}"
-            str << current_char if is_str
+          when '}'
+            str << current_char
+            next_char
             if is_in_interpolation
               is_in_interpolation = false
             end

--- a/src/slang/nodes/element.cr
+++ b/src/slang/nodes/element.cr
@@ -27,7 +27,7 @@ module Slang
           str << "#{buffer_name} << \" #{name}\"\n"
           if value
             str << "#{buffer_name} << \"=\\\"\"\n"
-            str << "#{buffer_name} << (#{value}).to_s.gsub(/&/,\"&amp;\").gsub(/\"/,\"&quot;\").gsub(/</,\"&lt;\").gsub(/>/,\"&gt;\")\n"
+            str << "#{buffer_name} << (#{value}).to_s.gsub(/\"/,\"&quot;\")\n"
             str << "#{buffer_name} << \"\\\"\"\n"
           end
         end

--- a/src/slang/nodes/element.cr
+++ b/src/slang/nodes/element.cr
@@ -27,7 +27,7 @@ module Slang
           str << "#{buffer_name} << \" #{name}\"\n"
           if value
             str << "#{buffer_name} << \"=\\\"\"\n"
-            str << "(#{value}).to_s #{buffer_name}\n"
+            str << "#{buffer_name} << (#{value}).to_s.gsub(/&/,\"&amp;\").gsub(/\"/,\"&quot;\").gsub(/</,\"&lt;\").gsub(/>/,\"&gt;\")\n"
             str << "#{buffer_name} << \"\\\"\"\n"
           end
         end


### PR DESCRIPTION
As per http://stackoverflow.com/questions/25612166/what-characters-must-be-escaped-in-html-5 it would seem you don't need to escape all characters in html attributes, but `< > " &` are advisable. `"` at the very least. I didn't use Crystal's `HTML.escape` as it looks like overkill for this issue.

I wanted to add the `==` option for unescaped but the attributes are stored in a hash so it wasn't easy to extend it to store the escaped / unescaped state without changing it to a hash of objects.

I've added a test incase someone wants to add this in the future.

This is a potentially breaking change so will require a version bump.

I'll see if I can come up with a fix for #6 and do a separate pull request for it.
