### PR TITLE
Boolean attributes, the eval way

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ html
     meta name="viewport" content="width=device-width,initial-scale=1.0"
     title This is a title
     css:
-      h1 {color: red;} 
+      h1 {color: red;}
       p {color: green;}
     style h2 {color: blue;}
   body
@@ -61,6 +61,9 @@ html
       p Dat browser is old.
     h1 This is a slang file
     h2 This is blue
+    input type="checkbox" checked=false
+    input type="checkbox" checked=true
+    input type="checkbox" checked="checked"
     span#some-id.classname
       #hello.world.world2
         - some_var = "hello world haha"
@@ -117,6 +120,9 @@ Compiles to HTML:
     <![endif]-->
     <h1>This is a slang file</h1>
     <h2>This is blue</h2>
+    <input type="checkbox"/>
+    <input type="checkbox" checked/>
+    <input type="checkbox" checked="checked"/>
     <span id="some-id" class="classname">
       <div id="hello" class="world world2">
         <span>
@@ -128,7 +134,7 @@ Compiles to HTML:
               </p>
               #{Process.pid}
               text node
-              other text node 
+              other text node
             </span>
           </span>
         </span>

--- a/spec/fixtures/boolean-attributes.slang
+++ b/spec/fixtures/boolean-attributes.slang
@@ -1,2 +1,6 @@
 input type="checkbox" checked=true
 input type="checkbox" checked=false
+input type="checkbox" checked="checked"
+input type="checkbox" checked=evaluates_to_true
+input type="checkbox" checked=evaluates_to_false
+input type="checkbox" checked=evaluates_to_hello

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -1,5 +1,17 @@
 require "./spec_helper"
 
+def evaluates_to_true
+  1 == 1
+end
+
+def evaluates_to_false
+  1 == 2
+end
+
+def evaluates_to_hello
+  "hello"
+end
+
 describe Slang do
   it "renders a basic document" do
     res = render_file("spec/fixtures/basic.slang")
@@ -291,6 +303,10 @@ describe Slang do
       res.should eq <<-HTML
       <input type="checkbox" checked>
       <input type="checkbox">
+      <input type="checkbox" checked="checked">
+      <input type="checkbox" checked>
+      <input type="checkbox">
+      <input type="checkbox" checked="hello">
       HTML
     end
   end

--- a/src/slang/nodes/element.cr
+++ b/src/slang/nodes/element.cr
@@ -28,13 +28,15 @@ module Slang
           str << "#{buffer_name} << \"\\\"\"\n"
         end
         attributes.each do |name, value|
-          next if value == "false" # don't want the attribute
+          str << "unless #{value} == false\n" # remove the attribute if value evaluates to false
           str << "#{buffer_name} << \" #{name}\"\n"
-          next if value == "true" # just want the attr there
+          str << "unless #{value} == true\n" # remove the value if value evaluates to true
           # any other attribute value.
           str << "#{buffer_name} << \"=\\\"\"\n"
           str << "#{buffer_name} << (#{value}).to_s.gsub(/\"/,\"&quot;\")\n"
           str << "#{buffer_name} << \"\\\"\"\n"
+          str << "end\n"
+          str << "end\n"
         end
         str << "#{buffer_name} << \">\"\n"
         if children?


### PR DESCRIPTION
hello

I was wondering it it's possible to remove attributes based on their value, like in Slim. then I found https://github.com/jeromegn/slang/issues/23 which solves this problem partially.

the problem with https://github.com/jeromegn/slang/issues/23 is that it won't evaluate the value. more specifically, to quote @crisward example:

```slim
- if active
     input type="checkbox" name="active" checked="checked"
- else
     input type="checkbox" name="active"
```

...it would be nice if this could be turned into:

```slim
input type="checkbox" name="active" checked=active
```

...but with the current state, that's not really possible. which is why I opened this PR.

note that complex conditions, like `checked=(1 == 1)` won't work, because the parser doesn't seem to like that right now - probably the same situation mentioned in https://github.com/jeromegn/slang/issues/37

another thing that I'd like to point out is that Slim checks (also?) for `nil` when removing attributes. not sure if we should go the same way, I don't really have a preference.

let me know what you think 🌵 🐫 