### PR TITLE
Multibyte characters handling improvement.

### DIFF
--- a/spec/fixtures/utf8.slang
+++ b/spec/fixtures/utf8.slang
@@ -1,0 +1,6 @@
+doctype html
+html
+  head
+    title Привет, мир
+  body
+    p Предложение

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -71,6 +71,21 @@ describe Slang do
     HTML
   end
 
+  it "renders a UTF8 text" do
+    res = render_file("spec/fixtures/utf8.slang")
+    res.should eq <<-HTML
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Привет, мир</title>
+      </head>
+      <body>
+        <p>Предложение</p>
+      </body>
+    </html>
+    HTML
+  end
+
   describe "attributes" do
     it "accepts string values" do
       render("span attr=\"hello\"").should eq <<-HTML

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -119,7 +119,7 @@ module Slang
         end
       end
 
-      go_back(current_attr_name.size)
+      go_back(current_attr_name.size, current_attr_name.bytesize)
     end
 
     private def consume_element_name
@@ -431,9 +431,9 @@ module Slang
       @token.type = :NEWLINE
     end
 
-    private def go_back(n)
-      @column_number -= n
-      @reader.pos -= n
+    private def go_back(column, bytes)
+      @column_number -= column
+      @reader.pos -= bytes
     end
 
     private def next_char


### PR DESCRIPTION
Currently when multibyte string is used in tags, the string is truncated at the beginning - parser consumes several bytes of text.
Larger text - more bytes will be consumed. Even there are conditions when consumed half of multibyte character that leads to curious result.

When the source contains

```
p Милиамперметр
```

The result looks like:

```
<p>�ерметр</p>
```

This PR fixes the problem.
Specs are also added.