### PR TITLE
Skip all spaces around and inside tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ html
     input type="checkbox" checked=false
     input type="checkbox" checked=true
     input type="checkbox" checked="checked"
+    span
+      | hello
+      = " "
+      | world
+    span
+      ' hello
+      | world
     span#some-id.classname
       #hello.world.world2
         - some_var = "hello world haha"
@@ -84,7 +91,7 @@ html
                 | text inside of <p>
               = Process.pid
               | text node
-              ' other text node
+              ' other text with space after it
         span.alongside pid=Process.pid
           custom-tag#with-id pid="#{Process.pid}"
             - ["ah", "oh"].each do |s|
@@ -109,7 +116,13 @@ some_var = "hello"
 strings = ["ah", "oh"]
 ```
 
-Compiles to HTML:
+Compiles to HTML without any spaces around and inside tags, just like ReactJS do:
+
+```html
+<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>This is a title</title><style>h1 {color: red;}p {color: green;}</style><style>h2 {color: blue;}</style></head><body><h1>This is a slang file</h1><h2>This is blue</h2><input type="checkbox"/><input type="checkbox" checked/><input type="checkbox" checked="checked"/><span>hello world</span><span>hello world</span><span id="some-id" class="classname"><div id="hello" class="world world2"><span><span data-some-var="hello world haha" two-attr="fun">and a hello</span><span><span class="deep_nested"><p>text inside of &lt;p&gt;</p>#{Process.pid}text nodeother text with space after it </span></span></span><span class="alongside" pid="#{Process.pid}"><custom-tag id="with-id" pid="#{Process.pid}"><span>ah</span><span>oh</span></custom-tag></span></div></span><div id="amazing-div" some-attr="hello"></div><script>var num1 = 8*4;</script><script>var num2 = 8*3;alert("8 * 3 + 8 * 4 = " + (num1 + num2));</script></body></html>
+```
+
+Beautified version of HTML would look like that (for reference only):
 
 ```html
 <!DOCTYPE html>
@@ -117,37 +130,27 @@ Compiles to HTML:
   <head>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>This is a title</title>
-    <style>
-      h1 {color: red;}
-      p {color: green;}
-    </style>
+    <style>h1 {color: red;}p {color: green;}</style>
     <style>h2 {color: blue;}</style>
   </head>
   <body>
-    <!--Visible multi-line comment
-      <span>this is wrapped in a comment</span>
-    -->
-    <!--[if IE]>
-      <p>Dat browser is old.</p>
-    <![endif]-->
+    <!--Visible multi-line comment<span>this is wrapped in a comment</span>-->
+    <!--[if IE]><p>Dat browser is old.</p><![endif]-->
     <h1>This is a slang file</h1>
     <h2>This is blue</h2>
     <input type="checkbox"/>
     <input type="checkbox" checked/>
     <input type="checkbox" checked="checked"/>
+    <span>hello world</span>
+    <span>hello world</span>
     <span id="some-id" class="classname">
       <div id="hello" class="world world2">
         <span>
           <span data-some-var="hello world haha" two-attr="fun">and a hello</span>
           <span>
             <span class="deep_nested">
-              <p>
-                text inside of &lt;p&gt;
-              </p>
-              #{Process.pid}
-              text node
-              other text node
-            </span>
+              <p>text inside of &lt;p&gt;</p>
+              #{Process.pid}text nodeother text with space after it </span>
           </span>
         </span>
         <span class="alongside" pid="#{Process.pid}">
@@ -161,10 +164,7 @@ Compiles to HTML:
     <div id="amazing-div" some-attr="hello"></div>
     <!--This is a visible comment-->
     <script>var num1 = 8*4;</script>
-    <script>
-      var num2 = 8*3;
-      alert("8 * 3 + 8 * 4 = " + (num1 + num2));
-    </script>
+    <script>var num2 = 8*3;alert("8 * 3 + 8 * 4 = " + (num1 + num2));</script>
   </body>
 </html>
 ```
@@ -173,6 +173,53 @@ Compiles to HTML:
 
 * `=` inserts HTML with escaped characters
 * `==` inserts HTML without escaping. It is needed when you have already rendered HTML and you need to insert it to your layout directly.
+
+### How to add spaces
+
+1. use `'` instead of `|` to add one space after text node
+
+```slim
+  span
+    ' hello
+    | world
+```
+
+```html
+  <span>hello world</span>
+```
+
+2. you can use `=` to add any number of spaces:
+
+```slim
+  span
+    = " "
+    | hello
+    = " "
+    | world
+    = " "
+```
+
+```html
+  <span> hello world </span>
+```
+
+### Limitation
+
+All JS and CSS code within `javascript:` and `css:` sections is minified in imperfect way, 
+so all space are removed even inside Template literals. For example:
+
+```slim
+  javascript:
+    let x = `
+    
+      string
+
+    `
+```
+
+```html
+  <script>let x = `string`</span>
+```
 
 ## TODO
 

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -16,74 +16,56 @@ end
 describe Slang do
   it "renders a basic document" do
     res = render_file("spec/fixtures/basic.slang")
-    res.should eq <<-HTML
-    <!DOCTYPE html>
-    <html>
-      <head>
-        <meta name="viewport" content="width=device-width,initial-scale=1.0">
-        <title>This is a title</title>
-        <style>
-          h1 {color: red;}
-          p {color: green;}
-        </style>
-        <style>h2 {color: blue;}</style>
-      </head>
-      <body>
-        <!--Multi-line comment
-          <span>this is wrapped in a comment</span>
-        -->
-        <!--[if IE]>
-          <p>Dat browser is old.</p>
-        <![endif]-->
-        <h1>This is a slang file</h1>
-        <h2>This is blue</h2>
-        <span id="some-id" class="classname">
-          <div id="hello" class="world world2">
-            <span>
-              <span data-some-var="hello world haha" two-attr="fun">and a hello</span>
-              <span>
-                <span class="deep_nested">
-                  <p>
-                    text inside of &lt;p&gt;
-                  </p>
-                  #{Process.pid}
-                  text node
-                  other text node 
-                </span>
-              </span>
-            </span>
-            <span class="alongside" pid="#{Process.pid}">
-              <custom-tag id="with-id" pid="#{Process.pid}">
-                <span>ah</span>
-                <span>oh</span>
-              </custom-tag>
-            </span>
-          </div>
-        </span>
-        <div id="amazing-div" some-attr="hello"></div>
-        <!--This is a visible comment-->
-        <script>var num1 = 8*4;</script>
-        <script>
-          var num2 = 8*3;
-          alert("8 * 3 + 8 * 4 = " + (num1 + num2));
-        </script>
-      </body>
-    </html>
-    HTML
+    res.should eq(
+      %(<!DOCTYPE html>) +
+      %(<html>) +
+      %(<head>) +
+      %(<meta name="viewport" content="width=device-width,initial-scale=1.0">) +
+      %(<title>This is a title</title>) +
+      %(<style>h1 {color: red;}p {color: green;}</style>) +
+      %(<style>h2 {color: blue;}</style>) +
+      %(</head>) +
+      %(<body>) +
+      %(<!--Multi-line comment<span>this is wrapped in a comment</span>-->) +
+      %(<!--[if IE]><p>Dat browser is old.</p><![endif]-->) +
+      %(<h1>This is a slang file</h1>) +
+      %(<h2>This is blue</h2>) +
+      %(<span id="some-id" class="classname">) +
+      %(<div id="hello" class="world world2">) +
+      %(<span>) +
+      %(<span data-some-var="hello world haha" two-attr="fun">and a hello</span>) +
+      %(<span>) +
+      %(<span class="deep_nested">) +
+      %(<p>) +
+      %(text inside of &lt;p&gt;) +
+      %(</p>) +
+      %(#{Process.pid}) +
+      %(text node) +
+      %(other text node ) +
+      %(</span>) +
+      %(</span>) +
+      %(</span>) +
+      %(<span class="alongside" pid="#{Process.pid}">) +
+      %(<custom-tag id="with-id" pid="#{Process.pid}">) +
+      %(<span>ah</span>) +
+      %(<span>oh</span>) +
+      %(</custom-tag>) +
+      %(</span>) +
+      %(</div>) +
+      %(</span>) +
+      %(<div id="amazing-div" some-attr="hello"></div>) +
+      %(<!--This is a visible comment-->) +
+      %(<script>var num1 = 8*4;</script>) +
+      %(<script>var num2 = 8*3;alert("8 * 3 + 8 * 4 = " + (num1 + num2));</script>) +
+      %(</body>) +
+      %(</html>)
+    )
   end
 
   it "renders a UTF8 text" do
     res = render_file("spec/fixtures/utf8.slang")
     res.should eq <<-HTML
-    <!DOCTYPE html>
-    <html>
-      <head>
-        <title>Привет, мир</title>
-      </head>
-      <body>
-        <p>Предложение</p>
-      </body>
-    </html>
+    <!DOCTYPE html><html><head><title>Привет, мир</title></head><body><p>Предложение</p></body></html>
     HTML
   end
 
@@ -99,6 +81,7 @@ describe Slang do
       <span attr="hello world"></span>
       HTML
     end
+
     it "allows dynamic classname" do
       klass = "my-class"
       render("span class=klass Foo").should eq <<-HTML
@@ -141,9 +124,7 @@ describe Slang do
       res = render_file "spec/fixtures/output.slang"
 
       res.should eq <<-HTML
-      <div>
-        hello
-      </div>
+      <div>hello</div>
       HTML
     end
 
@@ -166,15 +147,64 @@ describe Slang do
     end
   end
 
+  describe "spacing" do
+    it "is not added arround tag content" do
+      render(<<-SLANG
+      div hello world
+      SLANG
+      ).should eq <<-HTML
+      <div>hello world</div>
+      HTML
+    end
+
+    it "is not added with |" do
+      render(<<-SLANG
+      div
+        | hello
+        | world
+      SLANG
+      ).should eq <<-HTML
+      <div>helloworld</div>
+      HTML
+    end
+
+    it "is added with code" do
+      render(<<-SLANG
+      div
+        = " "
+        | hello
+        = " "
+      SLANG
+      ).should eq <<-HTML
+      <div> hello </div>
+      HTML
+    end
+
+    it "is added to the end with '" do
+      render(<<-SLANG
+      div
+        ' hello
+      SLANG
+      ).should eq <<-HTML
+      <div>hello </div>
+      HTML
+    end
+
+    it "is preserved from raw html" do
+      render(<<-SLANG
+      <div> hello world </div>
+      SLANG
+      ).should eq <<-HTML
+      <div> hello world </div>
+      HTML
+    end
+  end
+
   describe "raw html" do
     it "renders html" do
       res = render_file "spec/fixtures/with_html.slang"
-
       res.should eq <<-HTML
-      <table>
-        <tr><td>#{Process.pid}</td></tr>
-        <tr><td>"hello\\u0021"</td></tr>
-      </table>
+      <table><tr><td>#{Process.pid}</td></tr><tr><td>"hello\\u0021"</td></tr></table>
       HTML
     end
   end
@@ -182,13 +212,8 @@ describe Slang do
   describe "if elsif else" do
     it "renders the correct branches" do
       res = render_file "spec/fixtures/if-elsif-else.slang"
-
       res.should eq <<-HTML
-      <div>
-        <span>this guy is nested</span>
-        <span>deeply nested</span>
-        <span>true is just true man</span>
-      </div>
+      <div><span>this guy is nested</span><span>deeply nested</span><span>true is just true man</span></div>
       HTML
     end
   end
@@ -196,13 +221,8 @@ describe Slang do
   describe "case when" do
     it "renders the correct branches" do
       res = render_file "spec/fixtures/case-when.slang"
-
       res.should eq <<-HTML
-      <div>
-        <span>this guy is nested</span>
-        <span>deeply nested</span>
-        <span>true is just true man</span>
-      </div>
+      <div><span>this guy is nested</span><span>deeply nested</span><span>true is just true man</span></div>
       HTML
     end
   end
@@ -210,94 +230,71 @@ describe Slang do
   describe "begin rescue" do
     it "renders the correct branches" do
       res = render_file "spec/fixtures/begin-rescue.slang"
-
-      res.should eq <<-HTML
-      <div>
-        <span>beginning</span>
-        <span>rescued yup</span>
-        <span>beginning 2</span>
-        <span>rescued IndexError</span>
-        <span>beginning 3</span>
-        <span>nothing to rescue</span>
-      </div>
-      HTML
+      res.should eq(
+        %(<div>) +
+        %(<span>beginning</span>) +
+        %(<span>rescued yup</span>) +
+        %(<span>beginning 2</span>) +
+        %(<span>rescued IndexError</span>) +
+        %(<span>beginning 3</span>) +
+        %(<span>nothing to rescue</span>) +
+        %(</div>)
+      )
     end
   end
 
   describe "text node" do
     it "properly escapes double quotes" do
       res = render_file "spec/fixtures/double-quotes.slang"
-
-      res.should eq <<-HTML
-      <div>
-        <span>&quot;hello&quot;</span>
-        <span>&quot;hello&quot; world</span>
-        <span>&quot;hello&quot; &quot;world&quot;</span>
-        <span>&quot;hello world&quot;</span>
-        <span>&quot;hello world&quot;</span>
-        <span>&quot;hello world&quot;</span>
-        <span>&quot;hello world&quot;</span>
-        <span>&quot;hello world&quot;</span>
-        <span>&quot;hello world&quot;</span>
-        <span>&quot;hello&quot; &quot;world&quot;</span>
-      </div>
-      HTML
+      res.should eq(
+        %(<div>) +
+        %(<span>&quot;hello&quot;</span>) +
+        %(<span>&quot;hello&quot; world</span>) +
+        %(<span>&quot;hello&quot; &quot;world&quot;</span>) +
+        %(<span>&quot;hello world&quot;</span>) +
+        %(<span>&quot;hello world&quot;</span>) +
+        %(<span>&quot;hello world&quot;</span>) +
+        %(<span>&quot;hello world&quot;</span>) +
+        %(<span>&quot;hello world&quot;</span>) +
+        %(<span>&quot;hello world&quot;</span>) +
+        %(<span>&quot;hello&quot; &quot;world&quot;</span>) +
+        %(</div>)
+      )
     end
   end
 
   describe "svg tag" do
     it "renders tag attributes with colons" do
       res = render_file "spec/fixtures/svg.slang"
-      res.should eq <<-HTML
-      <div>
-        <svg width="256" height="448" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-          <defs>
-            <path id=\"shape1\" d=\"M184 144q0 3.25-2.375\"></path>
-            <path id=\"shape2\" d=\"M184 144q0 3.25-2.375\"></path>
-          </defs>
-        </svg>
-      </div>
-      HTML
+      res.should eq(
+        %(<div>) +
+        %(<svg width="256" height="448" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">) +
+        %(<defs>) +
+        %(<path id="shape1" d="M184 144q0 3.25-2.375"></path>) +
+        %(<path id="shape2" d="M184 144q0 3.25-2.375"></path>) +
+        %(</defs>) +
+        %(</svg>) +
+        %(</div>)
+      )
     end
   end
 
   describe "raw text" do
     it "renders javascript" do
       res = render_file "spec/fixtures/script.slang"
-      res.should eq <<-HTML
-      <script src="https://somecdn/vue.min.js"></script>
-      <script>
-        var num = 8*3;
-        console.log(num);
-      </script>
-      <script>var num = 8*4;</script>
-      <script>
-        new Vue({
-          el: '#app',
-          template: `
-            <div>
-              something
-            </div>
-          `
-        })
-      </script>
-      <script>
-        let twoLines = "bar\\nbaz";
-        let hello = "Hello, world!";
-        let obj = {"a":17,"b":"foo"};
-      </script>
-      HTML
+      res.should eq(
+        %(<script src="https://somecdn/vue.min.js"></script>) +
+        %(<script>var num = 8*3;console.log(num);</script>) +
+        %(<script>var num = 8*4;</script>) +
+        %(<script>new Vue({el: '#app',template: `<div>something</div>`})</script>) +
+        %(<script>let twoLines = "bar\\nbaz";let hello = "Hello, world!";let obj = {"a":17,"b":"foo"};</script>)
+      )
     end
+
     it "renders stylesheets" do
       res = render_file "spec/fixtures/style.slang"
       res.should eq <<-HTML
-      <style>
-        h1 {color:red;}
-        p {
-          color:blue;
-        }
-      </style>
-      <style>h2 {color:green;}</style>
+      <style>h1 {color:red;}p {color:blue;}</style><style>h2 {color:green;}</style>
       HTML
     end
   end
@@ -306,15 +303,13 @@ describe Slang do
     it "renders a simple block" do
       res = render_file "spec/fixtures/blocks.slang"
       res.should eq <<-HTML
-      \n<p>1</p>\n<p>2</p>\n<p>3</p>
+      <p>1</p><p>2</p><p>3</p>
       HTML
     end
 
     it "renders complex form helpers" do
       FormView.new.to_s.should eq <<-HTML
-      <form>
-        <input type="text" name="hello" \\>
-        <input type="submit"></form>
+      <form><input type="text" name="hello" \\><input type="submit"></form>
       HTML
     end
   end
@@ -322,54 +317,46 @@ describe Slang do
   describe "boolean attributes" do
     it "renders or not the attribute when a bool is used" do
       res = render_file "spec/fixtures/boolean-attributes.slang"
-      res.should eq <<-HTML
-      <input type="checkbox" checked>
-      <input type="checkbox">
-      <input type="checkbox" checked="checked">
-      <input type="checkbox" checked>
-      <input type="checkbox">
-      <input type="checkbox" checked="hello">
-      HTML
+      res.should eq(
+        %(<input type="checkbox" checked>) +
+        %(<input type="checkbox">) +
+        %(<input type="checkbox" checked="checked">) +
+        %(<input type="checkbox" checked>) +
+        %(<input type="checkbox">) +
+        %(<input type="checkbox" checked="hello">)
+      )
     end
   end
 
   describe "attribute wrappers" do
     it "renders attributes properly when wrapped" do
       res = render_file "spec/fixtures/attribute-wrappers.slang"
-      res.should eq <<-HTML
-      <div hello="world" foo="bar"></div>
-      <div hello="world" foo="bar"></div>
-      <div hello="world" foo="bar"></div>
-      <div hello="#{Process.pid}"></div>
-      <div hello="world" foo="bar"></div>
-      <div hello="world\\u0021" foo="bar"></div>
-      <div hello="world" foo="bar"></div>
-      <div hello="world!" foo="bar"></div>
-      HTML
+      res.should eq(
+        %(<div hello="world" foo="bar"></div>) +
+        %(<div hello="world" foo="bar"></div>) +
+        %(<div hello="world" foo="bar"></div>) +
+        %(<div hello="#{Process.pid}"></div>) +
+        %(<div hello="world" foo="bar"></div>) +
+        %(<div hello="world\\u0021" foo="bar"></div>) +
+        %(<div hello="world" foo="bar"></div>) +
+        %(<div hello="world!" foo="bar"></div>)
+      )
     end
   end
 
   describe "inline tags" do
     it "renders inlined tags" do
       res = render_file "spec/fixtures/inline-tags.slang"
-      res.should eq <<-HTML
-      <ul>
-        <li class="first">
-          <a href="/a">A link</a>
-        </li>
-        <li>
-          <a href="/b">B link</a>
-        </li>
-      </ul>
-      <ul>
-        <li class="first">
-          <a href="/a">A link</a>
-        </li>
-        <li>
-          <a href="/b">B link</a>
-        </li>
-      </ul>
-      HTML
+      res.should eq(
+        %(<ul>) +
+        %(<li class="first"><a href="/a">A link</a></li>) +
+        %(<li><a href="/b">B link</a></li>) +
+        %(</ul>) +
+        %(<ul>) +
+        %(<li class="first"><a href="/a">A link</a></li>) +
+        %(<li><a href="/b">B link</a></li>) +
+        %(</ul>)
+      )
     end
   end
 end

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -37,7 +37,6 @@ module Slang
       when '-'
         inline ? consume_text : consume_control
       when ':'
-        inline = false # don't consider this "inline" for output
         consume_inline_element
       when '='
         consume_output
@@ -49,14 +48,9 @@ module Slang
       when '/'
         consume_comment
       else
-        if inline
-          consume_text
-        else
-          unexpected_char
-        end
+        inline ? consume_text : unexpected_char
       end
 
-      @token.inline = inline unless @raw_text_column > 0
       @last_token = @token
       @token
     end
@@ -206,7 +200,7 @@ module Slang
       @token.type = :CONTROL
       next_char
       next_char if current_char == ' '
-      @token.value = consume_line(escape_double_quotes=false)
+      @token.value = consume_line(escape_double_quotes = false)
     end
 
     private def consume_output
@@ -228,7 +222,7 @@ module Slang
       end
 
       skip_whitespace
-      @token.value = consume_line(escape_double_quotes=false).strip
+      @token.value = consume_line(escape_double_quotes = false).strip
       @token.value = " #{@token.value}" if prepend_whitespace
       @token.value = "#{@token.value} " if append_whitespace
     end
@@ -349,7 +343,7 @@ module Slang
       @token.value = "\"#{consume_line}\""
     end
 
-    private def consume_line(escape_double_quotes=true)
+    private def consume_line(escape_double_quotes = true)
       String.build do |str|
         loop do
           if current_char == '\n' || current_char == '\0'

--- a/src/slang/node.cr
+++ b/src/slang/node.cr
@@ -23,6 +23,10 @@ module Slang
     end
 
     def to_s(str, buffer_name)
+      render_children(str, buffer_name)
+    end
+
+    private def render_children(str, buffer_name)
       nodes.each do |node|
         node.to_s(str, buffer_name)
       end

--- a/src/slang/node.cr
+++ b/src/slang/node.cr
@@ -1,7 +1,7 @@
 module Slang
   abstract class Node
     getter :parent, :token
-    delegate :value, :column_number, :line_number, :name, :escaped, :inline, to: @token
+    delegate :value, :column_number, :line_number, :name, :escaped, to: @token
 
     def initialize(@parent : Node, @token : Token)
     end
@@ -20,28 +20,6 @@ module Slang
 
     def document?
       false
-    end
-
-    def printable_parents_count
-      count = 0
-      current_parent = parent
-      until current_parent.is_a?(Document)
-        count += 1 unless current_parent.class.name.ends_with?("Control")
-        current_parent = current_parent.parent
-      end
-      return count
-    end
-
-    def indentation_spaces
-      printable_parents_count * 2
-    end
-
-    def indent?
-      !token.inline && indentation_spaces > 0
-    end
-
-    def indentation
-      indentation_spaces.times.map { " " }.join("")
     end
 
     def to_s(str, buffer_name)

--- a/src/slang/nodes/comment.cr
+++ b/src/slang/nodes/comment.cr
@@ -5,8 +5,6 @@ module Slang
 
       def to_s(str, buffer_name)
         if visible
-          str << "#{buffer_name} << \"\n\"\n" unless str.empty?
-          str << "#{buffer_name} << \"#{indentation}\"\n" if indent?
           str << "#{buffer_name} << \"<!--\"\n"
           str << "#{buffer_name} << \"[#{conditional}]>\"\n" if conditional?
           str << "#{buffer_name} << \"#{value}\"\n" if value
@@ -14,7 +12,6 @@ module Slang
             nodes.each do |node|
               node.to_s(str, buffer_name)
             end
-            str << "#{buffer_name} << \"\n#{indentation}\"\n"
           end
           str << "#{buffer_name} << \"<![endif]\"\n" if conditional?
           str << "#{buffer_name} << \"-->\"\n"

--- a/src/slang/nodes/control.cr
+++ b/src/slang/nodes/control.cr
@@ -69,17 +69,15 @@ module Slang
 
       def to_s(str, buffer_name)
         str << "#{value}\n"
-        if children?
-          nodes.each do |node|
-            node.to_s(str, buffer_name)
-          end
-        end
-        if branches?
-          branches.each do |branch|
-            branch.to_s(str, buffer_name)
-          end
-        end
+        render_children(str, buffer_name)
+        render_branches(str, buffer_name)
         str << "end\n" if endable?
+      end
+
+      private def render_branches(str, buffer_name)
+        branches.each do |branch|
+          branch.to_s(str, buffer_name)
+        end
       end
     end
   end

--- a/src/slang/nodes/element.cr
+++ b/src/slang/nodes/element.cr
@@ -16,8 +16,6 @@ module Slang
       end
 
       def to_s(str, buffer_name)
-        str << "#{buffer_name} << \"\n\"\n" unless str.empty?
-        str << "#{buffer_name} << \"#{indentation}\"\n" if indent?
         str << "#{buffer_name} << \"<#{name}\"\n"
         str << "#{buffer_name} << \" id=\\\"#{id}\\\"\"\n" if id
         c_names = generate_class_names
@@ -45,16 +43,8 @@ module Slang
           end
         end
         if !self_closing?
-          if children? && !only_inline_children?
-            str << "#{buffer_name} << \"\n\"\n"
-            str << "#{buffer_name} << \"#{indentation}\"\n" if indent?
-          end
           str << "#{buffer_name} << \"</#{name}>\"\n"
         end
-      end
-
-      def only_inline_children?
-        nodes.all? { |n| n.inline }
       end
 
       def self_closing?

--- a/src/slang/nodes/element.cr
+++ b/src/slang/nodes/element.cr
@@ -37,11 +37,7 @@ module Slang
           str << "end\n"
         end
         str << "#{buffer_name} << \">\"\n"
-        if children?
-          nodes.each do |node|
-            node.to_s(str, buffer_name)
-          end
-        end
+        render_children(str, buffer_name)
         if !self_closing?
           str << "#{buffer_name} << \"</#{name}>\"\n"
         end

--- a/src/slang/nodes/text.cr
+++ b/src/slang/nodes/text.cr
@@ -8,8 +8,6 @@ module Slang
       end
 
       def to_s(str, buffer_name)
-        str << "#{buffer_name} << \"\n\"\n" unless str.empty? || inline
-        str << "#{buffer_name} << \"#{indentation}\"\n" if indent?
         str << "#{buffer_name} << "
 
         # Escaping.

--- a/src/slang/nodes/text.cr
+++ b/src/slang/nodes/text.cr
@@ -19,9 +19,7 @@ module Slang
         if token.type == :OUTPUT && children?
           sub_buffer_name = "#{buffer_name}#{Random::Secure.hex(8)}"
           str << "(#{value}\nString.build do |#{sub_buffer_name}|\n"
-          nodes.each do |node|
-            node.to_s(str, "#{sub_buffer_name}")
-          end
+          render_children(str, sub_buffer_name)
           str << "end\nend)"
         else
           str << "(#{value})"
@@ -34,9 +32,7 @@ module Slang
         str << ".to_s(#{buffer_name})\n"
 
         if token.type != :OUTPUT && children?
-          nodes.each do |node|
-            node.to_s(str, buffer_name)
-          end
+          render_children(str, buffer_name)
         end
       end
     end

--- a/src/slang/token.cr
+++ b/src/slang/token.cr
@@ -7,7 +7,7 @@ module Slang
       :attributes,
       :id
 
-    property :value, :escaped, :inline, :visible, :conditional
+    property :value, :escaped, :visible, :conditional
 
     @value : String?
     @id : String?
@@ -19,7 +19,6 @@ module Slang
       @name = "div"
       @attributes = {} of String => (String | Set(String))
       @escaped = true
-      @inline = false
       @visible = true
       @conditional = ""
       @attributes["class"] = Set(String).new


### PR DESCRIPTION
Changes:
- all spaces are removed just like ReactJs does, so output code is almost minified
- small refactoring for children nodes rendering
- code inside `javascript:` and `css:` section is also minified so it pushes issues with JavaScript template literals even further. Before this change only empty lines inside template literals were remove, but now almost all spaces are removed inside them




I propose to add spaces using similar to ReactJS way: `= " "`
We can also use `'` to add space after text

This change allow to fix that
https://github.com/jeromegn/slang/issues/29
https://github.com/jeromegn/slang/issues/42