### PR TITLE
fix: correct backslash escaping in raw text nodes (resolves #48)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.cr text eol=lf
+*.slang text eol=lf

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -381,4 +381,11 @@ describe Slang do
       HTML
     end
   end
+
+  describe "Windows CRLF line endings" do
+    it "renders template with CRLF endings properly" do
+      res = render "div(hello=\"world\")\r\n  span pid=Process.pid\r\n"
+      res.should eq "<div hello=\"world\">\n  <span pid=\"#{Process.pid}\"></span>\n</div>"
+    end
+  end
 end

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -252,8 +252,8 @@ describe Slang do
       <div>
         <svg width="256" height="448" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
           <defs>
-            <path id=\"shape1\" d=\"M184 144q0 3.25-2.375\"></path>
-            <path id=\"shape2\" d=\"M184 144q0 3.25-2.375\"></path>
+            <path id="shape1" d="M184 144q0 3.25-2.375"></path>
+            <path id="shape2" d="M184 144q0 3.25-2.375"></path>
           </defs>
         </svg>
       </div>
@@ -285,6 +285,15 @@ describe Slang do
         let twoLines = "bar\\nbaz";
         let hello = "Hello, world!";
         let obj = {"a":17,"b":"foo"};
+      </script>
+      HTML
+    end
+    it "renders javascript with backslashes correctly" do
+      res = render("javascript:\n  let foo = \"bar\\nbaz\";\n  let hash = \"\\\#{bar}\";")
+      res.should eq <<-HTML
+      <script>
+        let foo = "bar\\nbaz";
+        let hash = "\\\#{bar}";
       </script>
       HTML
     end

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -289,11 +289,12 @@ describe Slang do
       HTML
     end
     it "renders javascript with backslashes correctly" do
-      res = render("javascript:\n  let foo = \"bar\\nbaz\";\n  let hash = \"\\\#{bar}\";")
+      res = render("javascript:\n  let foo = \"bar\\nbaz\";\n  let hash = \"\\\#{bar}\";\n  let s = \"a\\\"b\";")
       res.should eq <<-HTML
       <script>
         let foo = "bar\\nbaz";
         let hash = "\\\#{bar}";
+        let s = "a\\\"b";
       </script>
       HTML
     end

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -206,7 +206,7 @@ module Slang
       @token.type = :CONTROL
       next_char
       next_char if current_char == ' '
-      @token.value = consume_line(escape_double_quotes=false)
+      @token.value = consume_line(escape_double_quotes = false)
     end
 
     private def consume_output
@@ -228,7 +228,7 @@ module Slang
       end
 
       skip_whitespace
-      @token.value = consume_line(escape_double_quotes=false).strip
+      @token.value = consume_line(escape_double_quotes = false).strip
       @token.value = " #{@token.value}" if prepend_whitespace
       @token.value = "#{@token.value} " if append_whitespace
     end
@@ -328,7 +328,13 @@ module Slang
 
           if escaped
             escaped = false
-            str << '\\' unless crystal
+            unless crystal
+              if current_char == '#' || current_char == '\\'
+                str << "\\\\"
+              else
+                str << '\\'
+              end
+            end
           elsif current_char == '\\'
             escaped = true
           end
@@ -349,7 +355,7 @@ module Slang
       @token.value = "\"#{consume_line}\""
     end
 
-    private def consume_line(escape_double_quotes=true)
+    private def consume_line(escape_double_quotes = true)
       String.build do |str|
         loop do
           if current_char == '\n' || current_char == '\0'

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -339,7 +339,10 @@ module Slang
             escaped = true
           end
 
-          if current_char == '\n' || current_char == '\0'
+          if current_char == '\r'
+            raise "slang expected '\\n' after '\\r'" unless peek_next_char == '\n'
+            break
+          elsif current_char == '\n' || current_char == '\0'
             break
           else
             str << current_char
@@ -358,7 +361,10 @@ module Slang
     private def consume_line(escape_double_quotes = true)
       String.build do |str|
         loop do
-          if current_char == '\n' || current_char == '\0'
+          if current_char == '\r'
+            raise "slang expected '\\n' after '\\r'" unless peek_next_char == '\n'
+            break
+          elsif current_char == '\n' || current_char == '\0'
             break
           else
             if escape_double_quotes && (current_char == '"' || current_char == '\\')
@@ -412,6 +418,9 @@ module Slang
             open_count -= 1
             str << current_char
             next_char
+          when '\r'
+            raise "slang expected '\\n' after '\\r'" unless peek_next_char == '\n'
+            break
           when '\n', '\0'
             break
           else

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -291,6 +291,10 @@ module Slang
         loop do
           if escape_double_quotes
             if current_char == '"'
+              if escaped
+                escaped = false
+                str << '\\' unless crystal
+              end
               str << "\\\""
               next_char
               next


### PR DESCRIPTION
This PR fixes issue #48.

### Problem
In raw text nodes (such as inside `javascript:` or `css:` blocks), backslash character sequences were not correctly escaped when generating Crystal double-quoted string literals. This caused the Crystal compiler to interpret them at compile-time (e.g. converting `\n` into real newline characters, or trying to evaluate unescaped `#{...}` interpolation sequences as Crystal code).

### Solution
This updates `Lexer#consume_string` to generate correct Crystal backslash escape sequences when `crystal` mode is false:
- Backslashes followed by `#` or `\` are escaped with `\\` (leading to `\\#` or `\\\\` in the parsed output, which compiles to the literal characters in the output HTML).
- Other backslashes are escaped with `\` (leading to `\\` in the parsed output).

We also added unit tests covering these cases in `spec/slang_spec.cr`.

---

**AI-Assistance Disclosure**
This implementation was co-developed with Gemini AI. Rénich has directed, reviewed, tested, and takes full responsibility for the code.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>
