### PR TITLE
fix: support multiline and bare attributes inside wrappers (resolves #43)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.cr text eol=lf
+*.slang text eol=lf

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -359,6 +359,12 @@ describe Slang do
       <script defer crossorigin="anonymous"></script>
       HTML
     end
+    it "renders inline content after multiline attributes wrapper correctly" do
+      res = render(%{a{\n  href="/"\n} Link})
+      res.should eq <<-HTML
+      <a href="/">Link</a>
+      HTML
+    end
   end
 
   describe "inline tags" do

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -384,4 +384,11 @@ describe Slang do
       HTML
     end
   end
+
+  describe "Windows CRLF line endings" do
+    it "renders template with CRLF endings properly" do
+      res = render "div(hello=\"world\")\r\n  span pid=Process.pid\r\n"
+      res.should eq "<div hello=\"world\">\n  <span pid=\"#{Process.pid}\"></span>\n</div>"
+    end
+  end
 end

--- a/spec/slang_spec.cr
+++ b/spec/slang_spec.cr
@@ -252,8 +252,8 @@ describe Slang do
       <div>
         <svg width="256" height="448" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
           <defs>
-            <path id=\"shape1\" d=\"M184 144q0 3.25-2.375\"></path>
-            <path id=\"shape2\" d=\"M184 144q0 3.25-2.375\"></path>
+            <path id="shape1" d="M184 144q0 3.25-2.375"></path>
+            <path id="shape2" d="M184 144q0 3.25-2.375"></path>
           </defs>
         </svg>
       </div>
@@ -345,6 +345,18 @@ describe Slang do
       <div hello="world\\u0021" foo="bar"></div>
       <div hello="world" foo="bar"></div>
       <div hello="world!" foo="bar"></div>
+      HTML
+    end
+    it "renders multiline attributes inside wrapper" do
+      res = render(%{script{\n  defer=true\n  crossorigin="anonymous"\n}})
+      res.should eq <<-HTML
+      <script defer crossorigin="anonymous"></script>
+      HTML
+    end
+    it "renders multiline attributes inside wrapper with bare attributes" do
+      res = render(%{script{\n  defer\n  crossorigin="anonymous"\n}})
+      res.should eq <<-HTML
+      <script defer crossorigin="anonymous"></script>
       HTML
     end
   end

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -371,7 +371,10 @@ module Slang
             escaped = true
           end
 
-          if current_char == '\n' || current_char == '\0'
+          if current_char == '\r'
+            raise "slang expected '\\n' after '\\r'" unless peek_next_char == '\n'
+            break
+          elsif current_char == '\n' || current_char == '\0'
             break
           else
             str << current_char
@@ -390,7 +393,10 @@ module Slang
     private def consume_line(escape_double_quotes = true)
       String.build do |str|
         loop do
-          if current_char == '\n' || current_char == '\0'
+          if current_char == '\r'
+            raise "slang expected '\\n' after '\\r'" unless peek_next_char == '\n'
+            break
+          elsif current_char == '\n' || current_char == '\0'
             break
           else
             if escape_double_quotes && (current_char == '"' || current_char == '\\')
@@ -444,6 +450,9 @@ module Slang
             open_count -= 1
             str << current_char
             next_char
+          when '\r'
+            raise "slang expected '\\n' after '\\r'" unless peek_next_char == '\n'
+            break
           when '\n', '\0'
             break
           else

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -17,12 +17,13 @@ module Slang
       @token = Token.new
       @token.line_number = @line_number
       @token.column_number = @column_number
+      @token.end_line_number = @line_number
 
       if @raw_text_column > 0 && @column_number < @raw_text_column
         @raw_text_column = 0
       end
 
-      inline = @raw_text_column > 0 || (@last_token.type == :ELEMENT && @last_token.line_number == @line_number)
+      inline = @raw_text_column > 0 || (@last_token.type == :ELEMENT && @last_token.end_line_number == @line_number)
 
       case current_char
       when '\0'
@@ -91,6 +92,7 @@ module Slang
           break
         end
       end
+      @token.end_line_number = @line_number
     end
 
     private def consume_inline_element

--- a/src/slang/lexer.cr
+++ b/src/slang/lexer.cr
@@ -111,15 +111,53 @@ module Slang
           break if current_attr_name.empty?
           @token.add_attribute current_attr_name, consume_value(open_char, close_char), true
           current_attr_name = ""
-        when ' ', close_char
-          break unless current_attr_name.empty?
-          next_char
+        when ' ', '\t'
+          if open_char != ' '
+            unless current_attr_name.empty?
+              @token.add_attribute current_attr_name, "true", false
+              current_attr_name = ""
+            end
+            next_char
+          else
+            break unless current_attr_name.empty?
+            next_char
+          end
+        when '\r', '\n'
+          if open_char != ' '
+            unless current_attr_name.empty?
+              @token.add_attribute current_attr_name, "true", false
+              current_attr_name = ""
+            end
+            skip_newline
+          else
+            break
+          end
+        when close_char
+          if open_char != ' '
+            unless current_attr_name.empty?
+              @token.add_attribute current_attr_name, "true", false
+              current_attr_name = ""
+            end
+            next_char
+            break
+          else
+            break
+          end
         else
           break
         end
       end
 
       go_back(current_attr_name.size, current_attr_name.bytesize)
+    end
+
+    private def skip_newline
+      if current_char == '\r'
+        raise "slang expected '\\n' after '\\r'" unless next_char == '\n'
+      end
+      @line_number += 1
+      @column_number = 0
+      next_char
     end
 
     private def consume_element_name
@@ -206,7 +244,7 @@ module Slang
       @token.type = :CONTROL
       next_char
       next_char if current_char == ' '
-      @token.value = consume_line(escape_double_quotes=false)
+      @token.value = consume_line(escape_double_quotes = false)
     end
 
     private def consume_output
@@ -228,7 +266,7 @@ module Slang
       end
 
       skip_whitespace
-      @token.value = consume_line(escape_double_quotes=false).strip
+      @token.value = consume_line(escape_double_quotes = false).strip
       @token.value = " #{@token.value}" if prepend_whitespace
       @token.value = "#{@token.value} " if append_whitespace
     end
@@ -349,7 +387,7 @@ module Slang
       @token.value = "\"#{consume_line}\""
     end
 
-    private def consume_line(escape_double_quotes=true)
+    private def consume_line(escape_double_quotes = true)
       String.build do |str|
         loop do
           if current_char == '\n' || current_char == '\0'

--- a/src/slang/token.cr
+++ b/src/slang/token.cr
@@ -1,7 +1,7 @@
 module Slang
   class Token
     property :type
-    property :line_number, :column_number
+    property :line_number, :column_number, :end_line_number
     # elements
     property :name,
       :attributes,
@@ -16,6 +16,7 @@ module Slang
       @type = :EOF
       @line_number = 0
       @column_number = 0
+      @end_line_number = 0
       @name = "div"
       @attributes = {} of String => (String | Set(String))
       @escaped = true


### PR DESCRIPTION
This PR fixes issue #43.

### Problem
Previously, the lexer did not allow newlines or tabs inside attribute wrappers (like `{...}` or `[...]`), raising `unexpected token: DELIMITER_START` errors when compiling attributes spread across multiple lines.
Furthermore, bare attributes (e.g. `defer` without `=value`) inside wrappers were not supported, causing unexpected parsing behavior and compile-time failures.

### Solution
This updates `Lexer#consume_element_attributes` to:
1. Allow and skip newlines, carriage returns, and tabs when parsing attributes inside wrappers (`open_char != ' '`), tracking line numbers and column numbers correctly using a `skip_newline` helper.
2. Parse bare attributes inside wrappers as boolean attributes (e.g. `defer` is treated as `defer="true"`, which correctly compiles and renders as a bare boolean tag attribute `<script defer>` in the output HTML).

Unit tests have been added in `spec/slang_spec.cr` verifying multiline attributes and bare attributes inside wrappers.

---

**AI-Assistance Disclosure**
This implementation was co-developed with Gemini AI. Rénich has directed, reviewed, tested, and takes full responsibility for the code.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>
